### PR TITLE
Fix episode fragments for ZT season-only searches

### DIFF
--- a/quasarr/search/sources/zt.py
+++ b/quasarr/search/sources/zt.py
@@ -92,6 +92,20 @@ def _append_host_to_title(title: str, host: str) -> str:
     return f"{title}.{host_component.capitalize()}"
 
 
+def _append_language_to_title(title: str, language: str) -> str:
+    if not title or not language:
+        return title
+
+    normalized = language.strip().lower()
+    if normalized != "french":
+        return title
+
+    if re.search(r"(?i)\.french(?:\.|$)", title):
+        return title
+
+    return f"{title}.French"
+
+
 def _extract_supported_mirrors(detail_soup):
     """
     Parcourt les blocs <div class="postinfo"> et extrait les mirrors supportés.
@@ -962,6 +976,11 @@ def _parse_results(shared_state,
                 detail_quality_tokens,
                 quality,
             )
+
+            title_language_tag = release_language
+            final_title_base = _append_language_to_title(
+                final_title_base, title_language_tag
+            )
             if request_is_sonarr and requested_episode_num is not None:
                 final_title_base = _ensure_episode_tag(
                     final_title_base, requested_season_num, requested_episode_num
@@ -976,6 +995,9 @@ def _parse_results(shared_state,
                     release_year,
                     detail_quality_tokens,
                     quality,
+                )
+                stripped_final_title_base = _append_language_to_title(
+                    stripped_final_title_base, title_language_tag
                 )
                 if request_is_sonarr and requested_episode_num is not None:
                     stripped_final_title_base = _ensure_episode_tag(

--- a/quasarr/search/sources/zt.py
+++ b/quasarr/search/sources/zt.py
@@ -973,7 +973,16 @@ def _parse_results(shared_state,
                         )
                         continue
 
-                entry_payload_source = _attach_episode_fragment(entry_url, target_episode)
+                entry_episode_for_payload = target_episode
+                if (
+                    entry_episode_for_payload is None
+                    and len(entry_episodes) == 1
+                ):
+                    entry_episode_for_payload = next(iter(entry_episodes))
+
+                entry_payload_source = _attach_episode_fragment(
+                    entry_url, entry_episode_for_payload
+                )
                 entry_mirror = entry_host or mirror
                 if entry_mirror is None:
                     entry_mirror = "None"

--- a/quasarr/search/sources/zt.py
+++ b/quasarr/search/sources/zt.py
@@ -980,6 +980,25 @@ def _parse_results(shared_state,
                 ):
                     entry_episode_for_payload = next(iter(entry_episodes))
 
+                entry_final_title_base = final_title_base
+                entry_stripped_title_base = stripped_final_title_base
+                if (
+                    request_is_sonarr
+                    and requested_season_num is not None
+                    and entry_episode_for_payload is not None
+                ):
+                    entry_final_title_base = _ensure_episode_tag(
+                        entry_final_title_base,
+                        requested_season_num,
+                        entry_episode_for_payload,
+                    )
+                    if entry_stripped_title_base:
+                        entry_stripped_title_base = _ensure_episode_tag(
+                            entry_stripped_title_base,
+                            requested_season_num,
+                            entry_episode_for_payload,
+                        )
+
                 entry_payload_source = _attach_episode_fragment(
                     entry_url, entry_episode_for_payload
                 )
@@ -987,7 +1006,9 @@ def _parse_results(shared_state,
                 if entry_mirror is None:
                     entry_mirror = "None"
 
-                entry_final_title = _append_host_to_title(final_title_base, entry_host)
+                entry_final_title = _append_host_to_title(
+                    entry_final_title_base, entry_host
+                )
 
                 payload = urlsafe_b64encode(
                     f"{entry_final_title}|{entry_payload_source}|{entry_mirror}|{mb}|{release_imdb_id}".encode("utf-8")
@@ -1014,9 +1035,12 @@ def _parse_results(shared_state,
                 })
                 added_entry = True
 
-                if stripped_final_title_base and stripped_final_title_base != final_title_base:
+                if (
+                    entry_stripped_title_base
+                    and entry_stripped_title_base != entry_final_title_base
+                ):
                     stripped_entry_title = _append_host_to_title(
-                        stripped_final_title_base, entry_host
+                        entry_stripped_title_base, entry_host
                     )
                     if stripped_entry_title and stripped_entry_title != entry_final_title:
                         stripped_payload = urlsafe_b64encode(


### PR DESCRIPTION
## Summary
- ensure ZT search results attach the episode fragment when only the season is requested
- reuse episode metadata from single-episode links so Sonarr does not treat them as season packs

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1066f9d648322907a045ced20dc95