### PR TITLE
Add original title handling for ZT releases

### DIFF
--- a/.github/workflows/DockerAutoPush.yml
+++ b/.github/workflows/DockerAutoPush.yml
@@ -4,14 +4,6 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '.github/**'
-      - '*.md'
-      - 'LICENSE'
-
-env:
-  ENDPOINT: "rix1337/docker-quasarr"
-  GHCR_ENDPOINT: "ghcr.io/rix1337/quasarr"
 
 jobs:
   build-and-push:
@@ -20,44 +12,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Get version from source
-        id: version
-        run: echo "version=$(python3 quasarr/providers/version.py)" >> $GITHUB_OUTPUT
-
-      - name: Get short SHA
-        id: sha
-        run: echo "short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Set up QEMU (for multi-arch builds)
-        uses: docker/setup-qemu-action@v3
-
       - name: Log in to DockerHub
         uses: docker/login-action@v3
         with:
           username: "${{ secrets.DOCKERUSER }}"
           password: "${{ secrets.DOCKERPASS }}"
 
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: "${{ github.actor }}"
-          password: "${{ secrets.GITHUB_TOKEN }}"
-
-      - name: Build and push (multi-arch)
+      - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./docker/Dockerfile
-          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ${{ env.ENDPOINT }}:dev
-            ${{ env.ENDPOINT }}:dev-${{ steps.sha.outputs.short }}
-            ${{ env.GHCR_ENDPOINT }}:dev
-            ${{ env.GHCR_ENDPOINT }}:dev-${{ steps.sha.outputs.short }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+            kyliroco/quasarr:latest

--- a/.github/workflows/DockerAutoPush.yml
+++ b/.github/workflows/DockerAutoPush.yml
@@ -1,0 +1,63 @@
+name: Docker Auto Push
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '.github/**'
+      - '*.md'
+      - 'LICENSE'
+
+env:
+  ENDPOINT: "rix1337/docker-quasarr"
+  GHCR_ENDPOINT: "ghcr.io/rix1337/quasarr"
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get version from source
+        id: version
+        run: echo "version=$(python3 quasarr/providers/version.py)" >> $GITHUB_OUTPUT
+
+      - name: Get short SHA
+        id: sha
+        run: echo "short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set up QEMU (for multi-arch builds)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Log in to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: "${{ secrets.DOCKERUSER }}"
+          password: "${{ secrets.DOCKERPASS }}"
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: "${{ github.actor }}"
+          password: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Build and push (multi-arch)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.ENDPOINT }}:dev
+            ${{ env.ENDPOINT }}:dev-${{ steps.sha.outputs.short }}
+            ${{ env.GHCR_ENDPOINT }}:dev
+            ${{ env.GHCR_ENDPOINT }}:dev-${{ steps.sha.outputs.short }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/quasarr/api/__init__.py
+++ b/quasarr/api/__init__.py
@@ -8,6 +8,7 @@ import quasarr.providers.html_images as images
 from quasarr.api.arr import setup_arr_routes
 from quasarr.api.captcha import setup_captcha_routes
 from quasarr.api.config import setup_config
+from quasarr.api.debug_dashboard import setup_debug_routes
 from quasarr.api.sponsors_helper import setup_sponsors_helper_routes
 from quasarr.api.statistics import setup_statistics
 from quasarr.providers import shared_state
@@ -28,6 +29,7 @@ def get_api(shared_state_dict, shared_state_lock):
     setup_config(app, shared_state)
     setup_statistics(app, shared_state)
     setup_sponsors_helper_routes(app)
+    setup_debug_routes(app)
 
     @app.get('/')
     def index():
@@ -106,6 +108,7 @@ def get_api(shared_state_dict, shared_state_lock):
             <h2>🔧 Quick Actions</h2>
             <p><button class="btn-primary" onclick="location.href='/hostnames'">Update Hostnames</button></p>
             <p><button class="btn-primary" onclick="location.href='/statistics'">View Statistics</button></p>
+            <p><button class="btn-primary" onclick="location.href='/debug/'">Debug Dashboard</button></p>
         </div>
 
         <style>

--- a/quasarr/api/debug_dashboard.py
+++ b/quasarr/api/debug_dashboard.py
@@ -1,0 +1,369 @@
+# -*- coding: utf-8 -*-
+# Quasarr
+# Project by https://github.com/rix1337
+
+import json
+
+import quasarr.providers.html_images as images
+from quasarr.providers.html_templates import render_centered_html
+from quasarr.providers.log import get_log_entries, get_log_stats
+
+
+def setup_debug_routes(app):
+    # ------------------------------------------------------------------
+    # JSON API – used by the dashboard JS and available for external use
+    # ------------------------------------------------------------------
+
+    @app.get('/debug/api/logs')
+    def api_logs():
+        from bottle import request, response
+        response.content_type = 'application/json'
+
+        limit = int(request.query.get('limit', 200))
+        level = request.query.get('level', '') or None
+        source = request.query.get('source', '') or None
+        search = request.query.get('search', '') or None
+        since_id = int(request.query.get('since_id', 0))
+
+        entries = get_log_entries(
+            limit=limit,
+            level=level,
+            source=source,
+            search=search,
+            since_id=since_id,
+        )
+        return json.dumps({"entries": entries})
+
+    @app.get('/debug/api/stats')
+    def api_stats():
+        from bottle import response
+        response.content_type = 'application/json'
+        return json.dumps(get_log_stats())
+
+    # ------------------------------------------------------------------
+    # HTML dashboard
+    # ------------------------------------------------------------------
+
+    @app.get('/debug/')
+    @app.get('/debug')
+    def debug_dashboard():
+        content = f"""
+        <h1><img src="{images.logo}" type="image/png" alt="Quasarr logo" class="logo"/>Quasarr Debug</h1>
+
+        <div class="debug-controls">
+            <div class="filter-row">
+                <select id="levelFilter">
+                    <option value="">All levels</option>
+                    <option value="ERROR">ERROR</option>
+                    <option value="WARNING">WARNING</option>
+                    <option value="INFO">INFO</option>
+                    <option value="DEBUG">DEBUG</option>
+                </select>
+                <select id="sourceFilter">
+                    <option value="">All sources</option>
+                    <option value="zt">ZT (search)</option>
+                    <option value="zt-dl">ZT (download)</option>
+                    <option value="api">API</option>
+                </select>
+                <input id="searchFilter" type="text" placeholder="Search..." />
+                <button class="btn-primary small" onclick="fetchLogs()">Filter</button>
+                <button id="autoRefreshBtn" class="btn-secondary small" onclick="toggleAutoRefresh()">Auto-refresh: OFF</button>
+                <button class="btn-secondary small" onclick="location.href='/'">Back</button>
+            </div>
+        </div>
+
+        <div id="statsBar" class="stats-bar"></div>
+
+        <div id="logContainer" class="log-container">
+            <div class="log-loading">Loading...</div>
+        </div>
+
+        <!-- Modal for entry details -->
+        <div id="detailModal" class="modal" onclick="if(event.target===this)closeModal()">
+            <div class="modal-content">
+                <button class="modal-close" onclick="closeModal()">&times;</button>
+                <pre id="detailContent"></pre>
+            </div>
+        </div>
+
+        <style>
+            .debug-controls {{
+                margin: 15px 0;
+            }}
+            .filter-row {{
+                display: flex;
+                gap: 8px;
+                flex-wrap: wrap;
+                justify-content: center;
+                align-items: center;
+            }}
+            .filter-row select, .filter-row input {{
+                width: auto;
+                min-width: 120px;
+                padding: 6px 10px;
+                font-size: 0.875rem;
+                border-radius: 6px;
+            }}
+            .filter-row button.small {{
+                padding: 6px 12px;
+                font-size: 0.875rem;
+            }}
+            .stats-bar {{
+                display: flex;
+                gap: 12px;
+                justify-content: center;
+                flex-wrap: wrap;
+                margin: 12px 0;
+                font-size: 0.8rem;
+            }}
+            .stats-bar .stat {{
+                padding: 4px 10px;
+                border-radius: 12px;
+                font-weight: 600;
+            }}
+            .stat-searches {{ background: #e3f2fd; color: #1565c0; }}
+            .stat-found {{ background: #e8f5e9; color: #2e7d32; }}
+            .stat-filtered {{ background: #fff3e0; color: #e65100; }}
+            .stat-errors {{ background: #ffebee; color: #c62828; }}
+            .stat-total {{ background: var(--code-bg); color: var(--fg-color); }}
+
+            @media (prefers-color-scheme: dark) {{
+                .stat-searches {{ background: #0d47a1; color: #bbdefb; }}
+                .stat-found {{ background: #1b5e20; color: #c8e6c9; }}
+                .stat-filtered {{ background: #bf360c; color: #ffe0b2; }}
+                .stat-errors {{ background: #b71c1c; color: #ffcdd2; }}
+            }}
+
+            .log-container {{
+                max-height: 70vh;
+                overflow-y: auto;
+                text-align: left;
+                font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+                font-size: 0.8rem;
+                line-height: 1.5;
+                border: 1px solid var(--card-shadow);
+                border-radius: 8px;
+                background: var(--code-bg);
+            }}
+            .log-entry {{
+                padding: 6px 12px;
+                border-bottom: 1px solid rgba(128,128,128,0.15);
+                cursor: pointer;
+                transition: background 0.1s;
+                display: flex;
+                gap: 8px;
+                align-items: baseline;
+            }}
+            .log-entry:hover {{
+                background: rgba(128,128,128,0.1);
+            }}
+            .log-ts {{
+                color: var(--secondary);
+                white-space: nowrap;
+                flex-shrink: 0;
+                font-size: 0.75rem;
+            }}
+            .log-level {{
+                font-weight: 700;
+                white-space: nowrap;
+                flex-shrink: 0;
+                min-width: 55px;
+                text-align: center;
+                padding: 1px 6px;
+                border-radius: 4px;
+                font-size: 0.7rem;
+            }}
+            .log-level-DEBUG {{ color: #90a4ae; }}
+            .log-level-INFO {{ color: #42a5f5; }}
+            .log-level-WARNING {{ background: #fff3e0; color: #e65100; }}
+            .log-level-ERROR {{ background: #ffebee; color: #c62828; }}
+            @media (prefers-color-scheme: dark) {{
+                .log-level-WARNING {{ background: #4e342e; color: #ffab91; }}
+                .log-level-ERROR {{ background: #4e1a1a; color: #ef9a9a; }}
+            }}
+            .log-source {{
+                color: #7e57c2;
+                font-weight: 600;
+                white-space: nowrap;
+                flex-shrink: 0;
+            }}
+            .log-msg {{
+                flex: 1;
+                word-break: break-word;
+                overflow-wrap: anywhere;
+            }}
+            .log-data-badge {{
+                background: rgba(128,128,128,0.2);
+                color: var(--secondary);
+                font-size: 0.65rem;
+                padding: 1px 5px;
+                border-radius: 3px;
+                flex-shrink: 0;
+            }}
+            .log-loading {{
+                text-align: center;
+                padding: 40px;
+                color: var(--secondary);
+            }}
+            .modal {{
+                display: none;
+                position: fixed;
+                top: 0; left: 0; right: 0; bottom: 0;
+                background: rgba(0,0,0,0.5);
+                z-index: 1000;
+                justify-content: center;
+                align-items: center;
+            }}
+            .modal.active {{
+                display: flex;
+            }}
+            .modal-content {{
+                background: var(--card-bg);
+                border-radius: 12px;
+                padding: 24px;
+                max-width: 700px;
+                width: 90%;
+                max-height: 80vh;
+                overflow-y: auto;
+                position: relative;
+                box-shadow: 0 8px 32px rgba(0,0,0,0.3);
+            }}
+            .modal-close {{
+                position: absolute;
+                top: 8px; right: 12px;
+                background: none;
+                border: none;
+                font-size: 1.5rem;
+                cursor: pointer;
+                color: var(--fg-color);
+                margin: 0;
+                padding: 4px;
+            }}
+            #detailContent {{
+                white-space: pre-wrap;
+                word-break: break-word;
+                font-size: 0.8rem;
+                margin-top: 12px;
+            }}
+        </style>
+
+        <script>
+            let autoRefresh = false;
+            let refreshTimer = null;
+            let lastId = 0;
+
+            function fetchStats() {{
+                fetch('/debug/api/stats')
+                    .then(r => r.json())
+                    .then(stats => {{
+                        const bar = document.getElementById('statsBar');
+                        bar.innerHTML = `
+                            <span class="stat stat-total">${{stats.total}} total</span>
+                            <span class="stat stat-searches">${{stats.searches}} searches</span>
+                            <span class="stat stat-found">${{stats.results_found}} found</span>
+                            <span class="stat stat-filtered">${{stats.results_filtered}} filtered</span>
+                            <span class="stat stat-errors">${{stats.error}} errors</span>
+                        `;
+                    }});
+            }}
+
+            function fetchLogs() {{
+                const level = document.getElementById('levelFilter').value;
+                const source = document.getElementById('sourceFilter').value;
+                const search = document.getElementById('searchFilter').value;
+
+                const params = new URLSearchParams();
+                if (level) params.set('level', level);
+                if (source) params.set('source', source);
+                if (search) params.set('search', search);
+                params.set('limit', '300');
+
+                fetch('/debug/api/logs?' + params.toString())
+                    .then(r => r.json())
+                    .then(data => {{
+                        renderLogs(data.entries);
+                        if (data.entries.length > 0) {{
+                            lastId = Math.max(...data.entries.map(e => e.id));
+                        }}
+                    }});
+
+                fetchStats();
+            }}
+
+            function renderLogs(entries) {{
+                const container = document.getElementById('logContainer');
+                if (!entries.length) {{
+                    container.innerHTML = '<div class="log-loading">No log entries found</div>';
+                    return;
+                }}
+
+                let html = '';
+                for (const entry of entries) {{
+                    const ts = entry.timestamp ? entry.timestamp.split('T')[1].substring(0, 8) : '';
+                    const date = entry.timestamp ? entry.timestamp.split('T')[0] : '';
+                    const src = entry.source ? entry.source.toUpperCase() : '';
+                    const hasData = entry.data && Object.keys(entry.data).length > 0;
+                    const dataAttr = hasData ? ' data-detail="' + escapeAttr(JSON.stringify(entry, null, 2)) + '"' : '';
+                    const badge = hasData ? '<span class="log-data-badge">+data</span>' : '';
+
+                    html += `<div class="log-entry" onclick="showDetail(this)"${{dataAttr}}>
+                        <span class="log-ts" title="${{date}}">${{ts}}</span>
+                        <span class="log-level log-level-${{entry.level}}">${{entry.level}}</span>
+                        <span class="log-source">${{src}}</span>
+                        <span class="log-msg">${{escapeHtml(entry.message)}}</span>
+                        ${{badge}}
+                    </div>`;
+                }}
+                container.innerHTML = html;
+            }}
+
+            function escapeHtml(text) {{
+                const d = document.createElement('div');
+                d.textContent = text || '';
+                return d.innerHTML;
+            }}
+
+            function escapeAttr(text) {{
+                return (text || '').replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+            }}
+
+            function showDetail(el) {{
+                const raw = el.getAttribute('data-detail');
+                if (!raw) return;
+                try {{
+                    const obj = JSON.parse(raw);
+                    document.getElementById('detailContent').textContent = JSON.stringify(obj, null, 2);
+                    document.getElementById('detailModal').classList.add('active');
+                }} catch(e) {{
+                    document.getElementById('detailContent').textContent = raw;
+                    document.getElementById('detailModal').classList.add('active');
+                }}
+            }}
+
+            function closeModal() {{
+                document.getElementById('detailModal').classList.remove('active');
+            }}
+
+            function toggleAutoRefresh() {{
+                autoRefresh = !autoRefresh;
+                const btn = document.getElementById('autoRefreshBtn');
+                btn.textContent = autoRefresh ? 'Auto-refresh: ON' : 'Auto-refresh: OFF';
+                btn.className = autoRefresh ? 'btn-primary small' : 'btn-secondary small';
+
+                if (autoRefresh) {{
+                    refreshTimer = setInterval(fetchLogs, 5000);
+                }} else {{
+                    clearInterval(refreshTimer);
+                    refreshTimer = null;
+                }}
+            }}
+
+            document.getElementById('searchFilter').addEventListener('keydown', function(e) {{
+                if (e.key === 'Enter') fetchLogs();
+            }});
+
+            // Initial load
+            fetchLogs();
+        </script>
+        """
+        return render_centered_html(content)

--- a/quasarr/providers/imdb_metadata.py
+++ b/quasarr/providers/imdb_metadata.py
@@ -49,10 +49,24 @@ def get_localized_title(shared_state, imdb_id, language='de',original_title=Fals
     except Exception as e:
         info(f"Error loading IMDb metadata for {imdb_id}: {e}")
         return localized_title
+    soup = None
     if original_title:
         match = re.search(r">Titre original\s*:?(.+?)</div>", response.text, re.DOTALL)
         if match:
             titre_original = match.group(1).strip()
+        if not titre_original:
+            soup = BeautifulSoup(response.text, "html.parser")
+            aka_item = soup.find(
+                "li",
+                {"data-testid": "title-details-akas"},
+            )
+            if aka_item:
+                aka_text = aka_item.find(
+                    "span",
+                    class_="ipc-metadata-list-item__list-content-item",
+                )
+                if aka_text:
+                    titre_original = aka_text.get_text(strip=True)
     try:
         match = re.findall(r'<title>(.*?) \(.*?</title>', response.text)
         localized_title = match[0]

--- a/quasarr/providers/log.py
+++ b/quasarr/providers/log.py
@@ -4,16 +4,234 @@
 
 import datetime
 import os
+import threading
+import traceback
+from collections import deque
+
+# ---------------------------------------------------------------------------
+# Ring-buffer that stores the last N structured log entries in memory.
+# Thread-safe so it can be used from the Bottle request threads,
+# the JDownloader process relay, and any background workers.
+# ---------------------------------------------------------------------------
+
+_MAX_ENTRIES = 500
+_buffer_lock = threading.Lock()
+_log_buffer: deque = deque(maxlen=_MAX_ENTRIES)
+_event_id_counter = 0
+
+
+def _next_id():
+    global _event_id_counter
+    _event_id_counter += 1
+    return _event_id_counter
 
 
 def timestamp():
     return datetime.datetime.now().strftime("[%Y-%m-%d %H:%M:%S]")
 
 
-def info(string):
-    print(f"{timestamp()} {string}")
+def _now_iso():
+    return datetime.datetime.now().isoformat()
 
 
-def debug(string):
-    if os.getenv('DEBUG'):
-        info(string)
+# ---------------------------------------------------------------------------
+# Core internal logger – every public helper funnels through here.
+# ---------------------------------------------------------------------------
+
+def _emit(level: str, message: str, source: str = "", **extra):
+    """Write a log entry to stdout and to the in-memory ring buffer.
+
+    Parameters
+    ----------
+    level : str
+        One of "DEBUG", "INFO", "WARNING", "ERROR".
+    message : str
+        Human-readable log line.
+    source : str, optional
+        Module or subsystem that produced the entry (e.g. "zt", "api", "download").
+    **extra
+        Arbitrary structured data attached to the entry.  Anything JSON-serialisable
+        is fine – titles, URLs, payloads, filter reasons, etc.
+    """
+    ts = _now_iso()
+    entry = {
+        "id": _next_id(),
+        "timestamp": ts,
+        "level": level,
+        "source": source,
+        "message": message,
+    }
+    if extra:
+        entry["data"] = {k: v for k, v in extra.items() if v is not None}
+
+    with _buffer_lock:
+        _log_buffer.append(entry)
+
+    # Always print to stdout for docker logs / terminal visibility
+    prefix = f"[{ts.split('T')[0]} {ts.split('T')[1][:8]}]"
+    tag = f" [{source.upper()}]" if source else ""
+    level_tag = f" {level}" if level not in ("INFO",) else ""
+    print(f"{prefix}{tag}{level_tag} {message}", flush=True)
+
+
+# ---------------------------------------------------------------------------
+# Public helpers – drop-in replacements for the old info() / debug().
+# ---------------------------------------------------------------------------
+
+def info(message: str, source: str = "", **extra):
+    _emit("INFO", message, source=source, **extra)
+
+
+def debug(message: str, source: str = "", **extra):
+    if os.getenv("DEBUG"):
+        _emit("DEBUG", message, source=source, **extra)
+
+
+def warning(message: str, source: str = "", **extra):
+    _emit("WARNING", message, source=source, **extra)
+
+
+def error(message: str, source: str = "", include_traceback: bool = True, **extra):
+    if include_traceback:
+        tb = traceback.format_exc()
+        if tb and tb.strip() != "NoneType: None":
+            extra["traceback"] = tb
+    _emit("ERROR", message, source=source, **extra)
+
+
+# ---------------------------------------------------------------------------
+# Structured event logger – for key decision points (filtering, title
+# construction, payload building, etc.) that you want to inspect later
+# in the debug dashboard.
+# ---------------------------------------------------------------------------
+
+def log_event(event_type: str, source: str = "", level: str = "DEBUG", **data):
+    """Log a structured event with typed data.
+
+    This produces both a human-readable stdout line *and* a rich entry in the
+    ring buffer.  Use it at key decision points so the debug dashboard can
+    display exactly what happened and why.
+
+    Examples
+    --------
+    >>> log_event("release_filtered", source="zt",
+    ...           title="My.Movie.2024", reason="episode 3 not found")
+    >>> log_event("payload_built", source="zt",
+    ...           title="My.Movie.2024.1080p", payload_decoded="title|url|mirror|5000|tt123")
+    >>> log_event("api_request", source="api",
+    ...           method="tvsearch", requester="Sonarr", imdb_id="tt123", season="1", episode="3")
+    """
+    msg_parts = [event_type]
+    for key, value in data.items():
+        if value is not None:
+            msg_parts.append(f"{key}={value}")
+    message = " | ".join(msg_parts)
+
+    if level == "DEBUG" and not os.getenv("DEBUG"):
+        # Still store in buffer even without DEBUG so the dashboard can show it
+        ts = _now_iso()
+        entry = {
+            "id": _next_id(),
+            "timestamp": ts,
+            "level": "DEBUG",
+            "source": source,
+            "message": message,
+            "event_type": event_type,
+            "data": {k: v for k, v in data.items() if v is not None},
+        }
+        with _buffer_lock:
+            _log_buffer.append(entry)
+        return
+
+    _emit(level, message, source=source, event_type=event_type, **data)
+
+
+# ---------------------------------------------------------------------------
+# Buffer access for the debug dashboard / API.
+# ---------------------------------------------------------------------------
+
+def get_log_entries(limit: int = 200,
+                    level: str = None,
+                    source: str = None,
+                    search: str = None,
+                    since_id: int = 0):
+    """Return recent log entries, newest first.
+
+    Parameters
+    ----------
+    limit : int
+        Maximum number of entries to return.
+    level : str, optional
+        Filter by level (e.g. "ERROR", "WARNING").
+    source : str, optional
+        Filter by source substring (case-insensitive).
+    search : str, optional
+        Free-text search across message + data values (case-insensitive).
+    since_id : int
+        Only return entries whose id is strictly greater than this value.
+        Useful for incremental polling from the dashboard.
+    """
+    with _buffer_lock:
+        snapshot = list(_log_buffer)
+
+    if since_id:
+        snapshot = [e for e in snapshot if e["id"] > since_id]
+
+    if level:
+        level_upper = level.upper()
+        snapshot = [e for e in snapshot if e["level"] == level_upper]
+
+    if source:
+        source_lower = source.lower()
+        snapshot = [e for e in snapshot if source_lower in (e.get("source") or "").lower()]
+
+    if search:
+        search_lower = search.lower()
+
+        def _matches(entry):
+            if search_lower in entry.get("message", "").lower():
+                return True
+            for v in (entry.get("data") or {}).values():
+                if search_lower in str(v).lower():
+                    return True
+            return False
+
+        snapshot = [e for e in snapshot if _matches(e)]
+
+    # Newest first
+    snapshot.reverse()
+    return snapshot[:limit]
+
+
+def get_log_stats():
+    """Return summary counters for the dashboard header."""
+    with _buffer_lock:
+        snapshot = list(_log_buffer)
+
+    stats = {
+        "total": len(snapshot),
+        "debug": 0,
+        "info": 0,
+        "warning": 0,
+        "error": 0,
+        "searches": 0,
+        "results_found": 0,
+        "results_filtered": 0,
+        "downloads": 0,
+    }
+    for entry in snapshot:
+        lvl = entry.get("level", "").lower()
+        if lvl in stats:
+            stats[lvl] += 1
+
+        event_type = entry.get("event_type") or (entry.get("data") or {}).get("event_type")
+        if event_type == "search_request":
+            stats["searches"] += 1
+        elif event_type == "release_accepted":
+            stats["results_found"] += 1
+        elif event_type == "release_filtered":
+            stats["results_filtered"] += 1
+        elif event_type in ("download_request", "download_attempt"):
+            stats["downloads"] += 1
+
+    return stats

--- a/quasarr/search/sources/by.py
+++ b/quasarr/search/sources/by.py
@@ -109,7 +109,8 @@ def _parse_posts(soup, shared_state, base_url, password, mirror_filter,
                     if not (RESOLUTION_REGEX.search(title) or CODEC_REGEX.search(title)):
                         continue
 
-                if not shared_state.is_valid_release(title, request_from, search_string, season, episode):
+                valid, _reject_reason = shared_state.is_valid_release(title, request_from, search_string, season, episode)
+                if not valid:
                     continue
                 if XXX_REGEX.search(title) and 'xxx' not in search_string.lower():
                     continue

--- a/quasarr/search/sources/dd.py
+++ b/quasarr/search/sources/dd.py
@@ -92,11 +92,12 @@ def dd_search(shared_state, start_time, request_from, search_string="", mirror=N
                 else:
                     title = release.get("release")
 
-                    if not shared_state.is_valid_release(title,
-                                                         request_from,
-                                                         search_string,
-                                                         season,
-                                                         episode):
+                    valid, _reject_reason = shared_state.is_valid_release(title,
+                                                                        request_from,
+                                                                        search_string,
+                                                                        season,
+                                                                        episode)
+                    if not valid:
                         continue
 
                     imdb_id = release.get("imdbid", None)

--- a/quasarr/search/sources/dt.py
+++ b/quasarr/search/sources/dt.py
@@ -206,11 +206,12 @@ def dt_search(shared_state, start_time, request_from, search_string, mirror=None
                          replace(')', '')
                          )
 
-                if not shared_state.is_valid_release(title,
-                                                     request_from,
-                                                     search_string,
-                                                     season,
-                                                     episode):
+                valid, _reject_reason = shared_state.is_valid_release(title,
+                                                                    request_from,
+                                                                    search_string,
+                                                                    season,
+                                                                    episode)
+                if not valid:
                     continue
 
                 if 'lazylibrarian' in request_from.lower():

--- a/quasarr/search/sources/dw.py
+++ b/quasarr/search/sources/dw.py
@@ -167,11 +167,12 @@ def dw_search(shared_state, start_time, request_from, search_string, mirror=None
             try:
                 title = result.a.text.strip()
 
-                if not shared_state.is_valid_release(title,
-                                                                     request_from,
-                                                                     search_string,
-                                                                     season,
-                                                                     episode):
+                valid, _reject_reason = shared_state.is_valid_release(title,
+                                                                    request_from,
+                                                                    search_string,
+                                                                    season,
+                                                                    episode)
+                if not valid:
                     continue
 
                 if not imdb_id:

--- a/quasarr/search/sources/fx.py
+++ b/quasarr/search/sources/fx.py
@@ -168,11 +168,12 @@ def fx_search(shared_state, start_time, request_from, search_string, mirror=None
                         link = title["href"]
                         title = shared_state.sanitize_title(title.text)
 
-                        if not shared_state.is_valid_release(title,
-                                                             request_from,
-                                                             search_string,
-                                                             season,
-                                                             episode):
+                        valid, _reject_reason = shared_state.is_valid_release(title,
+                                                                            request_from,
+                                                                            search_string,
+                                                                            season,
+                                                                            episode)
+                        if not valid:
                             continue
 
                         try:

--- a/quasarr/search/sources/mb.py
+++ b/quasarr/search/sources/mb.py
@@ -68,11 +68,12 @@ def _parse_posts(soup, shared_state, password, mirror_filter,
                     published = dt_obj.strftime("%a, %d %b %Y %H:%M:%S +0000")
 
             if is_search:
-                if not shared_state.is_valid_release(title,
-                                                     request_from,
-                                                     search_string,
-                                                     season,
-                                                     episode):
+                valid, _reject_reason = shared_state.is_valid_release(title,
+                                                                    request_from,
+                                                                    search_string,
+                                                                    season,
+                                                                    episode)
+                if not valid:
                     continue
 
                 # drop .XXX. unless user explicitly searched xxx

--- a/quasarr/search/sources/me.py
+++ b/quasarr/search/sources/me.py
@@ -162,11 +162,12 @@ def _parse_results(shared_state,
                 continue
 
             if search_string is not None:
-                if not shared_state.is_valid_release(title,
-                                                     request_from,
-                                                     search_string,
-                                                     season,
-                                                     episode):
+                valid, _reject_reason = shared_state.is_valid_release(title,
+                                                                    request_from,
+                                                                    search_string,
+                                                                    season,
+                                                                    episode)
+                if not valid:
                     debug(
                         f"{hostname.upper()} filtered title '{title}' "
                         f"for requester={request_from}, search='{search_string}'"

--- a/quasarr/search/sources/nx.py
+++ b/quasarr/search/sources/nx.py
@@ -141,11 +141,12 @@ def nx_search(shared_state, start_time, request_from, search_string, mirror=None
             if item['type'] == valid_type:
                 title = item['name']
                 if title:
-                    if not shared_state.is_valid_release(title,
-                                                         request_from,
-                                                         search_string,
-                                                         season,
-                                                         episode):
+                    valid, _reject_reason = shared_state.is_valid_release(title,
+                                                                        request_from,
+                                                                        search_string,
+                                                                        season,
+                                                                        episode)
+                    if not valid:
                         continue
 
                     if 'lazylibrarian' in request_from.lower():

--- a/quasarr/search/sources/sf.py
+++ b/quasarr/search/sources/sf.py
@@ -342,11 +342,12 @@ def sf_search(shared_state, start_time, request_from, search_string, mirror=None
                         continue
 
                 # check down here on purpose, because the title may be modified at episode stage
-                if not shared_state.is_valid_release(title,
-                                                     request_from,
-                                                     search_string,
-                                                     season,
-                                                     episode):
+                valid, _reject_reason = shared_state.is_valid_release(title,
+                                                                    request_from,
+                                                                    search_string,
+                                                                    season,
+                                                                    episode)
+                if not valid:
                     continue
 
                 payload = urlsafe_b64encode(f"{title}|{source}|{mirror}|{mb}|{password}|{imdb_id}".encode()).decode()

--- a/quasarr/search/sources/sl.py
+++ b/quasarr/search/sources/sl.py
@@ -159,11 +159,12 @@ def sl_search(shared_state, start_time, request_from, search_string, mirror=None
                 a = post.find('h1').find('a')
                 title = a.get_text(strip=True)
 
-                if not shared_state.is_valid_release(title,
-                                                     request_from,
-                                                     search_string,
-                                                     season,
-                                                     episode):
+                valid, _reject_reason = shared_state.is_valid_release(title,
+                                                                    request_from,
+                                                                    search_string,
+                                                                    season,
+                                                                    episode)
+                if not valid:
                     continue
 
                 if 'lazylibrarian' in request_from.lower():

--- a/quasarr/search/sources/wd.py
+++ b/quasarr/search/sources/wd.py
@@ -92,11 +92,12 @@ def _parse_rows(
 
             # search context contains non-video releases (ebooks, games, etc.)
             if is_search:
-                if not shared_state.is_valid_release(title,
-                                                     request_from,
-                                                     search_string,
-                                                     season,
-                                                     episode):
+                valid, _reject_reason = shared_state.is_valid_release(title,
+                                                                    request_from,
+                                                                    search_string,
+                                                                    season,
+                                                                    episode)
+                if not valid:
                     continue
 
                 if 'lazylibrarian' in request_from.lower():

--- a/quasarr/search/sources/zt.py
+++ b/quasarr/search/sources/zt.py
@@ -1044,6 +1044,12 @@ def _parse_results(shared_state,
                     original_title_base = _ensure_episode_tag(
                         original_title_base, requested_season_num, requested_episode_num
                     )
+                if (
+                    original_title_base
+                    and final_title_base
+                    and original_title_base.lower() == final_title_base.lower()
+                ):
+                    original_title_base = None
 
             size_bytes = mb * 1024 * 1024 if mb else 0
             release_date = parse_date_fr(published)
@@ -1165,6 +1171,13 @@ def _parse_results(shared_state,
                             base_season_number,
                             entry_episode_for_title,
                         )
+                    if (
+                        original_title_with_episode
+                        and final_title_with_episode
+                        and original_title_with_episode.lower()
+                        == final_title_with_episode.lower()
+                    ):
+                        original_title_with_episode = None
 
                     if original_title_with_episode:
                         original_title_for_host = (

--- a/quasarr/search/sources/zt.py
+++ b/quasarr/search/sources/zt.py
@@ -540,6 +540,7 @@ def _normalize_title(title):
     normalized = _strip_diacritics(normalized)
     normalized = re.sub(r"[:：]", " ", normalized)
     normalized = re.sub(r"[’']", "", normalized)
+    normalized = normalized.replace(",", " ")
     normalized = normalized.replace(" - ", "-")
     normalized = re.sub(r"\s+", " ", normalized).strip()
     normalized = normalized.replace(" ", ".")

--- a/quasarr/search/sources/zt.py
+++ b/quasarr/search/sources/zt.py
@@ -758,27 +758,23 @@ def _parse_results(shared_state,
 
             require_episode_verification = False
             if search_string is not None:
-                if not shared_state.is_valid_release(raw_title,
-                                                     request_from,
-                                                     search_string,
-                                                     season,
-                                                     episode):
+                valid, reject_reason = shared_state.is_valid_release(
+                    raw_title, request_from, search_string, season, episode,
+                )
+                if not valid:
                     if (
                         request_is_sonarr
                         and season is not None
                         and episode is not None
-                        and shared_state.is_valid_release(
-                            raw_title,
-                            request_from,
-                            search_string,
-                            season,
-                            None,
-                        )
                     ):
-                        require_episode_verification = True
-                    else:
+                        valid_season_only, _ = shared_state.is_valid_release(
+                            raw_title, request_from, search_string, season, None,
+                        )
+                        if valid_season_only:
+                            require_episode_verification = True
+                    if not require_episode_verification:
                         log_event("release_filtered", source="zt",
-                                  title=raw_title, reason="is_valid_release rejected",
+                                  title=raw_title, reason=reject_reason,
                                   requester=request_from, search=search_string)
                         continue
 

--- a/quasarr/search/sources/zt.py
+++ b/quasarr/search/sources/zt.py
@@ -524,15 +524,28 @@ def _strip_parenthetical_content(text):
     return re.sub(r"\s+", " ", stripped).strip()
 
 
+def _strip_diacritics(text):
+    if not text:
+        return text
+
+    normalized = unicodedata.normalize("NFD", text)
+    return "".join(ch for ch in normalized if unicodedata.category(ch) != "Mn")
+
+
 def _normalize_title(title):
     if not title:
         return title
 
     normalized = normalize_localized_season_episode_tags(title)
+    normalized = _strip_diacritics(normalized)
+    normalized = re.sub(r"[:：]", " ", normalized)
+    normalized = re.sub(r"[’']", "", normalized)
     normalized = normalized.replace(" - ", "-")
+    normalized = re.sub(r"\s+", " ", normalized).strip()
     normalized = normalized.replace(" ", ".")
     normalized = normalized.replace("(", "").replace(")", "")
-    return normalized
+    normalized = re.sub(r"\.+", ".", normalized)
+    return normalized.strip(".")
 
 
 def _normalize_quality_token(token):
@@ -1340,11 +1353,6 @@ def zt_search(shared_state,
             search_original= html.unescape(original)
         else:
             search_original = None
-    def _strip_diacritics(text):
-        if not text:
-            return text
-        normalized = unicodedata.normalize("NFD", text)
-        return "".join(ch for ch in normalized if unicodedata.category(ch) != "Mn")
 
     seen_links = set()
     aggregated_releases = []

--- a/quasarr/search/sources/zt.py
+++ b/quasarr/search/sources/zt.py
@@ -292,7 +292,7 @@ def _extract_detail_title(soup):
     if not soup:
         return None
 
-    title_tag = soup.find("h1")
+    title_tag = soup.select_one(".centersideinn h1")
     if title_tag:
         text = title_tag.get_text(strip=True)
         if text:


### PR DESCRIPTION
## Summary
- parse Zone-Téléchargement detail pages to capture the original title field
- include the extracted original title alongside localized releases when building search results

## Testing
- python -m compileall quasarr/search/sources/zt.py

------
https://chatgpt.com/codex/tasks/task_e_68f3a98f8eb08322a9392bb3565ccdf3