### PR TITLE
Refine ZT title normalization

### DIFF
--- a/quasarr/search/sources/zt.py
+++ b/quasarr/search/sources/zt.py
@@ -483,6 +483,7 @@ def _normalize_title(title):
         ch for ch in normalized if unicodedata.category(ch) != "Mn"
     )
     normalized = normalized.replace(":", " ")
+    normalized = normalized.replace(",", " ")
     normalized = normalized.replace("'", "").replace("\u2019", "")
     normalized = normalized.replace(" - ", "-")
     normalized = normalized.replace("(", "").replace(")", "")


### PR DESCRIPTION
## Summary
- strip diacritics, apostrophes, colons, and duplicate whitespace when normalizing Zone-Téléchargement titles

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e28b7092c08322a9123ec63c032184