### PR TITLE
fix: use a real Chrome version in User-Agent to avoid IMDb bot detection

### DIFF
--- a/quasarr/__init__.py
+++ b/quasarr/__init__.py
@@ -101,7 +101,7 @@ def run():
         supported_hostnames = extract_allowed_keys(Config._DEFAULT_CONFIG, 'Hostnames')
         shared_state.update("sites", [key.upper() for key in supported_hostnames])
         shared_state.update("user_agent",
-                            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36")
+                            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
         shared_state.update("helper_active", False)
 
         print(f'Config path: "{config_path}"')


### PR DESCRIPTION
Chrome/139.0.0.0 doesn't exist (latest stable is ~120), which IMDb flags as a bot. Switch to Chrome/120.0.0.0 which matches a real released version and is what was confirmed to return valid HTML from IMDb.

https://claude.ai/code/session_01GrWmTETDRoAq9k4NSzNSGe