### PR TITLE
feat: add debug mode toggle button and log IMDb request headers

### DIFF
--- a/quasarr/api/debug_dashboard.py
+++ b/quasarr/api/debug_dashboard.py
@@ -6,7 +6,7 @@ import json
 
 import quasarr.providers.html_images as images
 from quasarr.providers.html_templates import render_centered_html
-from quasarr.providers.log import get_log_entries, get_log_stats
+from quasarr.providers.log import get_log_entries, get_log_stats, set_debug_mode, is_debug_mode
 
 
 def setup_debug_routes(app):
@@ -40,6 +40,21 @@ def setup_debug_routes(app):
         response.content_type = 'application/json'
         return json.dumps(get_log_stats())
 
+    @app.get('/debug/api/debug-mode')
+    def api_debug_mode_get():
+        from bottle import response
+        response.content_type = 'application/json'
+        return json.dumps({"enabled": is_debug_mode()})
+
+    @app.post('/debug/api/debug-mode')
+    def api_debug_mode_set():
+        from bottle import request, response
+        response.content_type = 'application/json'
+        body = request.json or {}
+        enabled = bool(body.get("enabled", False))
+        set_debug_mode(enabled)
+        return json.dumps({"enabled": is_debug_mode()})
+
     # ------------------------------------------------------------------
     # HTML dashboard
     # ------------------------------------------------------------------
@@ -68,6 +83,7 @@ def setup_debug_routes(app):
                 <input id="searchFilter" type="text" placeholder="Search..." />
                 <button class="btn-primary small" onclick="fetchLogs()">Filter</button>
                 <button id="autoRefreshBtn" class="btn-secondary small" onclick="toggleAutoRefresh()">Auto-refresh: OFF</button>
+                <button id="debugModeBtn" class="btn-secondary small" onclick="toggleDebugMode()">Debug: OFF</button>
                 <button class="btn-secondary small" onclick="location.href='/'">Back</button>
             </div>
         </div>
@@ -362,7 +378,28 @@ def setup_debug_routes(app):
                 if (e.key === 'Enter') fetchLogs();
             }});
 
+            function updateDebugBtn(enabled) {{
+                const btn = document.getElementById('debugModeBtn');
+                btn.textContent = enabled ? 'Debug: ON' : 'Debug: OFF';
+                btn.className = enabled ? 'btn-primary small' : 'btn-secondary small';
+            }}
+
+            function toggleDebugMode() {{
+                fetch('/debug/api/debug-mode')
+                    .then(r => r.json())
+                    .then(data => {{
+                        return fetch('/debug/api/debug-mode', {{
+                            method: 'POST',
+                            headers: {{'Content-Type': 'application/json'}},
+                            body: JSON.stringify({{enabled: !data.enabled}})
+                        }});
+                    }})
+                    .then(r => r.json())
+                    .then(data => updateDebugBtn(data.enabled));
+            }}
+
             // Initial load
+            fetch('/debug/api/debug-mode').then(r => r.json()).then(d => updateDebugBtn(d.enabled));
             fetchLogs();
         </script>
         """

--- a/quasarr/providers/imdb_metadata.py
+++ b/quasarr/providers/imdb_metadata.py
@@ -44,11 +44,13 @@ def get_localized_title(shared_state, imdb_id, language='de',original_title=Fals
         'User-Agent': shared_state.values["user_agent"]
     }
 
+    info(f"IMDb request headers for {imdb_id}: {headers}", source="imdb")
     try:
         response = requests.get(f"https://www.imdb.com/title/{imdb_id}/", headers=headers, timeout=10)
     except Exception as e:
         info(f"Error loading IMDb metadata for {imdb_id}: {e}")
         return localized_title, None
+    info(f"IMDb response status for {imdb_id}: {response.status_code}, body length: {len(response.text)}", source="imdb")
     debug(f"IMDb response status for {imdb_id}: {response.status_code}")
     if response.status_code >= 300:
         info(f"IMDb returned HTTP {response.status_code} for {imdb_id}")
@@ -100,12 +102,13 @@ def get_type(shared_state, imdb_id, language='de'):
         'User-Agent': shared_state.values["user_agent"]
     }
 
+    info(f"IMDb request headers for {imdb_id}: {headers}", source="imdb")
     try:
         response = requests.get(f"https://www.imdb.com/title/{imdb_id}/", headers=headers, timeout=10)
     except Exception as e:
         info(f"Error loading IMDb metadata for {imdb_id}: {e}")
         return []
-    debug(f"IMDb response status for {imdb_id}: {response.status_code}")
+    info(f"IMDb response status for {imdb_id}: {response.status_code}, body length: {len(response.text)}", source="imdb")
     if response.status_code >= 300:
         info(f"IMDb returned HTTP {response.status_code} for {imdb_id}")
         return []
@@ -113,7 +116,7 @@ def get_type(shared_state, imdb_id, language='de'):
 
     # 1) Chercher le bloc JSON-LD principal et parser `genre`
     ld_tags = soup.find_all("script", type="application/ld+json")
-    debug(f"IMDb JSON-LD tags found for {imdb_id}: {len(ld_tags)}, body length: {len(response.text)}")
+    info(f"IMDb JSON-LD tags found for {imdb_id}: {len(ld_tags)}", source="imdb")
     genres = []
     for tag in ld_tags:
         try:

--- a/quasarr/providers/log.py
+++ b/quasarr/providers/log.py
@@ -19,6 +19,17 @@ _buffer_lock = threading.Lock()
 _log_buffer: deque = deque(maxlen=_MAX_ENTRIES)
 _event_id_counter = 0
 
+_debug_mode: bool = bool(os.getenv("DEBUG"))
+
+
+def set_debug_mode(enabled: bool):
+    global _debug_mode
+    _debug_mode = enabled
+
+
+def is_debug_mode() -> bool:
+    return _debug_mode
+
 
 def _next_id():
     global _event_id_counter
@@ -83,7 +94,7 @@ def info(message: str, source: str = "", **extra):
 
 
 def debug(message: str, source: str = "", **extra):
-    if os.getenv("DEBUG"):
+    if _debug_mode:
         _emit("DEBUG", message, source=source, **extra)
 
 
@@ -127,7 +138,7 @@ def log_event(event_type: str, source: str = "", level: str = "DEBUG", **data):
             msg_parts.append(f"{key}={value}")
     message = " | ".join(msg_parts)
 
-    if level == "DEBUG" and not os.getenv("DEBUG"):
+    if level == "DEBUG" and not _debug_mode:
         # Still store in buffer even without DEBUG so the dashboard can show it
         ts = _now_iso()
         entry = {


### PR DESCRIPTION
- log.py: replace os.getenv("DEBUG") with a runtime-togglable _debug_mode flag, exposed via set_debug_mode() / is_debug_mode()
- debug_dashboard.py: add GET/POST /debug/api/debug-mode endpoints and a "Debug: ON/OFF" button in the UI that toggles debug logging live
- imdb_metadata.py: log request headers and response status/body length at INFO level so they always appear, regardless of debug mode

https://claude.ai/code/session_01GrWmTETDRoAq9k4NSzNSGe